### PR TITLE
Downgrade wf from 22 to 21

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        wildfly: [20.0.1.Final, 21.0.1.Final]
+        wildfly: [20.0.1.Final]
     name: build with wildfly ${{matrix.wildfly}}
 
     steps:

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
 
     <properties>
         <!-- Target WildFly version, and other parts needed for the Galleon maven plugin -->
-        <version.org.wildfly>22.0.0.Alpha1</version.org.wildfly>
+        <version.org.wildfly>21.0.2.Final</version.org.wildfly>
         <version.org.wildfly.core>12.0.1.Final</version.org.wildfly.core>
         <version.org.wildfly.common>1.5.4.Final</version.org.wildfly.common>
         <version.org.jboss.galleon>4.2.5.Final</version.org.jboss.galleon>


### PR DESCRIPTION
It turns out that WF 22 includes a breaking change by moving microprofile modules to a different feature pack, and I think we can't build our feature pack just once in a way that will work both with WF 21 and 22.
We will probably esolve building for WF 22 later in a different branch.