### PR TITLE
Allow running the quickstart's tests when a local WildFly instance is…

### DIFF
--- a/quickstart/pom.xml
+++ b/quickstart/pom.xml
@@ -35,6 +35,10 @@
         <!-- these are only relevant for testing -->
         <jboss.dist>${project.basedir}/target/wildfly</jboss.dist>
         <jboss.home>${jboss.dist}</jboss.home>
+        <!-- Where the testing WF instance will be bound.
+         If the user has already started their WF instance for experimenting with the quickstart, it is most likely
+         on 127.0.0.1, so let's try 127.0.0.2 to avoid clashing and run a separate instance. -->
+        <node0>127.0.0.2</node0>
     </properties>
 
     <licenses>
@@ -46,7 +50,6 @@
     </licenses>
 
     <!-- just override dependencyManagement from parent because we don't want to exclude transitive deps
-    TODO: the client example should probably moved to a separate quickstart
     -->
     <dependencyManagement>
         <dependencies>
@@ -92,7 +95,6 @@
         <dependency>
             <groupId>io.smallrye</groupId>
             <artifactId>smallrye-graphql-client-api</artifactId>
-            <version>${version.io.smallrye.graphql}</version>
             <scope>test</scope>
         </dependency>
 
@@ -183,6 +185,8 @@
                 <configuration>
                     <systemPropertyVariables combine.children="append">
                         <jboss.install.dir>${project.build.directory}/wildfly</jboss.install.dir>
+                        <server.jvm.args>-Djboss.bind.address=${node0} -Djboss.bind.address.management=${node0} -Djboss.bind.address.unsecure=${node0}</server.jvm.args>
+                        <node0>${node0}</node0>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>

--- a/quickstart/src/test/java/org/wildfly/extras/quickstart/microprofile/graphql/test/TypesafeGraphQLClientTestCase.java
+++ b/quickstart/src/test/java/org/wildfly/extras/quickstart/microprofile/graphql/test/TypesafeGraphQLClientTestCase.java
@@ -20,6 +20,7 @@ import io.smallrye.graphql.client.typesafe.api.GraphQlClientBuilder;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
@@ -30,12 +31,16 @@ import org.wildfly.extras.quickstart.microprofile.graphql.Film;
 import org.wildfly.extras.quickstart.microprofile.graphql.Hero;
 import org.wildfly.extras.quickstart.microprofile.graphql.LightSaber;
 
+import java.net.URL;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 
 @RunWith(Arquillian.class)
 public class TypesafeGraphQLClientTestCase {
+
+    @ArquillianResource
+    URL url;
 
     @Deployment(name = "server", testable = false)
     public static WebArchive serverDeployment() {
@@ -57,8 +62,11 @@ public class TypesafeGraphQLClientTestCase {
     @Test
     @OperateOnDeployment("client")
     public void testGetAllFilms() {
+        // ArquillianResource injects the URL of the deployment where we are running the test, so replace 'client' with 'server'
+        // to get the context root of the 'server' deployment (which contains the GraphQL endpoint)
+        String endpoint = url.toString().replace("client", "server") + "graphql";
         GalaxyClientApi client = GraphQlClientBuilder.newBuilder()
-                .endpoint("http://localhost:8080/server/graphql")
+                .endpoint(endpoint)
                 .build(GalaxyClientApi.class);
 
         List<Film> allFilms = client.getAllFilms();

--- a/quickstart/src/test/resources/arquillian.xml
+++ b/quickstart/src/test/resources/arquillian.xml
@@ -23,10 +23,10 @@
         <configuration>
             <property name="jbossHome">${jboss.install.dir}</property>
             <property name="serverConfig">${jboss.server.config.file.name:standalone.xml}</property>
-            <property name="allowConnectingToRunningServer">true</property>
+            <property name="javaVmArguments">${server.jvm.args}</property>
+            <property name="allowConnectingToRunningServer">false</property>
             <property name="managementAddress">${node0:127.0.0.1}</property>
             <property name="managementPort">${as.managementPort:9990}</property>
-            <property name="waitForPorts">${as.debug.port:8787} ${as.managementPort:9990}</property>
             <property name="waitForPortsTimeoutInSeconds">8</property>
         </configuration>
     </container>


### PR DESCRIPTION
… already running

Fixes #59 