### PR TITLE
fix #111: update wildfly-plugin and configure for dev mode in quickstart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@ target
 # gradle
 .gradle
 **/gradle/wrapper
+
+/quickstart/wildfly/

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ See [Installation guide](https://github.com/wildfly-extras/wildfly-graphql-featu
 **For development purposes, one way to obtain a WildFly distribution with a snapshot of this feature pack installed is to simply build the contents of this repository.
 After building (`mvn clean install`), it will appear under build/target/wildfly-$VERSION. The Galleon definition of what will be included can be found in `build/pom.xml`.**
 
+You can also build a server by using the wildfly plugin, maybe even in `dev` mode. See the Quickstart for details.
 
 -------------
 

--- a/feature-pack/pom.xml
+++ b/feature-pack/pom.xml
@@ -79,6 +79,7 @@
             <plugin>
                 <groupId>org.wildfly.maven.plugins</groupId>
                 <artifactId>licenses-plugin</artifactId>
+                <version>2.3.1.Final</version>
                 <inherited>false</inherited>
                 <executions>
                     <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
         <!-- Plugin versions and their dependency versions -->
         <version.org.wildfly.checkstyle-config>1.0.8.Final</version.org.wildfly.checkstyle-config>
         <version.org.wildfly.galleon-plugins>6.4.2.Final</version.org.wildfly.galleon-plugins>
-        <version.wildfly.maven.plugin>2.2.0.Final</version.wildfly.maven.plugin>
+        <version.wildfly.maven.plugin>4.1.0.Final</version.wildfly.maven.plugin>
 
         <!-- Misc. -->
         <wildfly-extras.repo.scm.connection>git@github.com:wildfly-extras/wildfly-graphql-feature-pack.git</wildfly-extras.repo.scm.connection>

--- a/quickstart/README.md
+++ b/quickstart/README.md
@@ -2,26 +2,16 @@
 
 ## Prerequisites
 - JDK 1.8+
-- Maven 
-- Galleon downloaded and available on your path as described in the [main README](../README.md). The main README also provides background on how to provision WildFly servers and which Galleon layers are available.
+- Maven
 
 
 ## Building and deploying the quickstart
-You need to provision a server (remember you need to have Galleon installed as described in 
-the [main README](../README.md)). Go to the folder containing this README in a new
-terminal, and then run:
-```
-galleon.sh provision ./provision.xml --dir=target/my-wildfly
-./target/my-wildfly/bin/standalone.sh
-```
-This provisions the server with the relevant Galleon layers, and starts it. The
-[main README](../README.md) contains information about the layers in this feature pack.
 
-Then in another terminal window, go to the same folder and run:
+The [main README](../README.md) contains information about the layers in this feature pack. You can use the `wildfly-maven-plugin` to build and run the server with the feature pack, and deploy the quickstart war.
+
 ```
-mvn package wildfly:deploy
+mvn wildfly:provision wildfly:dev
 ```
-This builds and deploys the application into the provisioned WildFly server.
 
 ## Check the GraphQL schema
 To view the schema, execute this command:

--- a/quickstart/pom.xml
+++ b/quickstart/pom.xml
@@ -124,6 +124,7 @@
         <dependency>
             <groupId>jakarta.validation</groupId>
             <artifactId>jakarta.validation-api</artifactId>
+            <scope>provided</scope>
         </dependency>
 
         <!-- Other dependencies needed for the testing infrastructure -->
@@ -156,6 +157,22 @@
                 <!-- To be able to deploy the app by doing mvn package wildfly:deploy -->
                 <groupId>org.wildfly.plugins</groupId>
                 <artifactId>wildfly-maven-plugin</artifactId>
+                <configuration>
+                    <feature-packs>
+                        <feature-pack>
+                            <location>wildfly@maven(org.jboss.universe:community-universe):current#${version.org.wildfly}</location>
+                        </feature-pack>
+                        <feature-pack>
+                            <location>org.wildfly.extras.graphql:wildfly-microprofile-graphql-feature-pack:${project.version}</location>
+                        </feature-pack>
+                    </feature-packs>
+                    <layers>
+                        <layer>cloud-server</layer>
+                        <layer>jmx-remoting</layer>
+                        <layer>management</layer>
+                        <layer>microprofile-graphql</layer>
+                    </layers>
+                </configuration>
             </plugin>
 
             <!-- Prepare a WildFly distribution for testing. Only relevant for the tests. -->

--- a/testsuite/client-vertx/pom.xml
+++ b/testsuite/client-vertx/pom.xml
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>jakarta.json</groupId>
             <artifactId>jakarta.json-api</artifactId>
-            <scope>test</scope>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.eclipse</groupId>
@@ -134,10 +134,6 @@
             <groupId>org.glassfish</groupId>
             <artifactId>jakarta.json</artifactId>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.json</groupId>
-            <artifactId>jakarta.json-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.wildfly.arquillian</groupId>


### PR DESCRIPTION
also fixed some pom issues.

Note that I have some problems with the `TypesafeGraphQLClientTestCase` (even without any changes). It fails to start the server, because the server can't open the admin port 9990.

I also have issues with the Galleon plugin. When I run `mvn galleon:provision`, it complains about missing parameters `featurePacks`, `installDir`, as they are named `feature-packs` and `install-dir`.