### PR TITLE
Some further alignment for wildfly 28

### DIFF
--- a/feature-pack/src/main/resources/modules/system/layers/base/io/smallrye/graphql/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/io/smallrye/graphql/main/module.xml
@@ -59,10 +59,9 @@
         <module name="jakarta.json.api" export="true"/>
         <module name="jakarta.json.bind.api"/>
         <module name="jakarta.validation.api" optional="true"/>
-        <module name="io.smallrye.metrics" optional="true"/>
-        <module name="io.smallrye.opentracing" optional="true"/>
-        <module name="io.opentracing.opentracing-api" optional="true"/>
-        <module name="org.eclipse.microprofile.metrics.api" optional="true"/>
+        <module name="io.opentelemetry.api" optional="true"/>
+        <module name="io.opentelemetry.context" optional="true"/>
+        <module name="io.micrometer" optional="true"/>
         <module name="org.slf4j"/>
 
         <module name="io.undertow.websocket"/>

--- a/quickstart/pom.xml
+++ b/quickstart/pom.xml
@@ -171,6 +171,8 @@
                         <layer>jmx-remoting</layer>
                         <layer>management</layer>
                         <layer>microprofile-graphql</layer>
+                        <layer>micrometer</layer>
+                        <layer>microprofile-telemetry</layer>
                     </layers>
                 </configuration>
             </plugin>
@@ -187,7 +189,7 @@
                         </goals>
                         <phase>test-compile</phase>
                         <configuration>
-                            <install-dir>${project.build.directory}/wildfly</install-dir>
+                            <install-dir>${project.build.directory}/wildfly-test</install-dir>
                             <record-state>false</record-state>
                             <log-time>${galleon.log.time}</log-time>
                             <plugin-options>
@@ -222,6 +224,8 @@
                                         <layer>observability</layer>
                                         <!-- Layers from this FP -->
                                         <layer>microprofile-graphql</layer>
+                                        <layer>micrometer</layer>
+                                        <layer>microprofile-telemetry</layer>
                                     </layers>
                                 </config>
                             </configurations>
@@ -234,7 +238,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <systemPropertyVariables combine.children="append">
-                        <jboss.install.dir>${project.build.directory}/wildfly</jboss.install.dir>
+                        <jboss.install.dir>${project.build.directory}/wildfly-test</jboss.install.dir>
                         <server.jvm.args>-Djboss.bind.address=${node0} -Djboss.bind.address.management=${node0} -Djboss.bind.address.unsecure=${node0}</server.jvm.args>
                         <node0>${node0}</node0>
                     </systemPropertyVariables>


### PR DESCRIPTION
Module dependency adjustments:
- remove MP Metrics 
- add Micrometer 
- remove opentracing 
- add opentelemetry

Also renames the directory under `quickstart/target` where the Galleon plugin provisions an instance for testing purposes. Now, it will live in directory named `wildfly-test`, not `wildfly`, to prevent some possible confusion.
The instance provisioned for actually running the quickstart is under `target/server`.