### PR TITLE
WildFly Glow layers metadata and upgrade to WildFly 30.0.0.Final

### DIFF
--- a/feature-pack/src/main/resources/layers/standalone/microprofile-graphql/layer-spec.xml
+++ b/feature-pack/src/main/resources/layers/standalone/microprofile-graphql/layer-spec.xml
@@ -15,7 +15,10 @@
   ~ limitations under the License.
   -->
 
-<layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="microprofile-graphql">
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="microprofile-graphql">
+    <props>
+        <prop name="org.wildfly.rule.annotations" value="org.eclipse.microprofile.graphql"/>
+    </props>
     <dependencies>
         <layer name="cdi"/>
         <layer name="microprofile-config"/>

--- a/pom.xml
+++ b/pom.xml
@@ -585,6 +585,11 @@
                     <version>${version.org.jboss.galleon}</version>
                 </plugin>
                 <plugin>
+                    <groupId>org.wildfly.glow</groupId>
+                    <artifactId>wildfly-glow-arquillian-plugin</artifactId>
+                    <version>${version.wildfly.glow}</version>
+                </plugin>
+                <plugin>
                     <groupId>org.wildfly.galleon-plugins</groupId>
                     <artifactId>wildfly-galleon-maven-plugin</artifactId>
                     <version>${version.org.wildfly.galleon-plugins}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -38,11 +38,11 @@
     </licenses>
 
     <properties>
-	    <!-- Target WildFly version, and other parts needed for the Galleon maven plugin -->
-        <version.org.wildfly>29.0.0.Final-SNAPSHOT</version.org.wildfly>
-        <version.org.wildfly.core>21.1.0.Beta2</version.org.wildfly.core>
+	<!-- Target WildFly version, and other parts needed for the Galleon maven plugin -->
+        <version.org.wildfly>30.0.0.Final</version.org.wildfly>
+        <version.org.wildfly.core>22.0.1.Final</version.org.wildfly.core>
         <version.org.wildfly.common>1.6.0.Final</version.org.wildfly.common>
-        <version.org.jboss.galleon>5.2.0.Final</version.org.jboss.galleon>
+        <version.org.jboss.galleon>5.2.2.Final</version.org.jboss.galleon>
 
         <!-- Other WildFly feature pack that we depend on -->
         <version.org.wildfly.reactive-feature-pack>3.0.0.Final</version.org.wildfly.reactive-feature-pack> 
@@ -77,10 +77,8 @@
         <version.tyrus>1.1</version.tyrus>
         <version.junit>4.13.1</version.junit>
         <version.rest-assured>5.3.0</version.rest-assured>
-        <version.arquillian>5.0.0.Alpha6</version.arquillian>
         <version.arquillian-junit>1.7.0.Alpha12</version.arquillian-junit>
-        <version.wildfly.glow>1.0.0.Alpha1</version.wildfly.glow>
-        <version.org.testng>7.4.0</version.org.testng>
+        <version.wildfly.glow>1.0.0.Alpha7</version.wildfly.glow>
 
         <!-- Plugin versions and their dependency versions -->
         <version.org.wildfly.checkstyle-config>1.0.8.Final</version.org.wildfly.checkstyle-config>
@@ -411,6 +409,13 @@
             </dependency>
             <dependency>
                 <groupId>org.wildfly</groupId>
+                <artifactId>wildfly-standard-test-expansion-bom</artifactId>
+                <version>${version.org.wildfly}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.wildfly</groupId>
                 <artifactId>wildfly-standard-expansion-bom</artifactId>
                 <version>${version.org.wildfly}</version>
                 <type>pom</type>
@@ -493,20 +498,6 @@
 
             <!-- Stuff used for testing only -->
             <dependency>
-                <!-- Not sure why the wildfly and wildfly-core upgrades made this necessary -->
-                <groupId>org.wildfly.arquillian</groupId>
-                <artifactId>wildfly-arquillian-container-managed</artifactId>
-                <scope>test</scope>
-                <version>${version.arquillian}</version>
-            </dependency>
-            <dependency>
-                <!-- Not sure why the wildfly and wildfly-core upgrades made this necessary -->
-                <groupId>org.wildfly.arquillian</groupId>
-                <artifactId>wildfly-arquillian-protocol-jmx</artifactId>
-                <scope>test</scope>
-                <version>${version.arquillian}</version>
-            </dependency>
-            <dependency>
                 <groupId>org.jboss.arquillian.junit</groupId>
                 <artifactId>arquillian-junit-container</artifactId>
                 <version>${version.arquillian-junit}</version>
@@ -582,13 +573,6 @@
                 <groupId>io.rest-assured</groupId>
                 <artifactId>rest-assured</artifactId>
                 <version>${version.rest-assured}</version>
-            </dependency>
-            <!-- Not sure why the wildfly and wildfly-core upgrades made this necessary -->
-            <dependency>
-                <groupId>org.testng</groupId>
-                <artifactId>testng</artifactId>
-                <version>${version.org.testng}</version>
-                <scope>test</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -39,8 +39,8 @@
 
     <properties>
 	    <!-- Target WildFly version, and other parts needed for the Galleon maven plugin -->
-        <version.org.wildfly>28.0.1.Final</version.org.wildfly>
-        <version.org.wildfly.core>20.0.1.Final</version.org.wildfly.core>
+        <version.org.wildfly>29.0.0.Final-SNAPSHOT</version.org.wildfly>
+        <version.org.wildfly.core>21.1.0.Beta2</version.org.wildfly.core>
         <version.org.wildfly.common>1.6.0.Final</version.org.wildfly.common>
         <version.org.jboss.galleon>5.2.0.Final</version.org.jboss.galleon>
 
@@ -77,7 +77,10 @@
         <version.tyrus>1.1</version.tyrus>
         <version.junit>4.13.1</version.junit>
         <version.rest-assured>5.3.0</version.rest-assured>
+        <version.arquillian>5.0.0.Alpha6</version.arquillian>
         <version.arquillian-junit>1.7.0.Alpha12</version.arquillian-junit>
+        <version.wildfly.glow>1.0.0.Alpha1</version.wildfly.glow>
+        <version.org.testng>7.4.0</version.org.testng>
 
         <!-- Plugin versions and their dependency versions -->
         <version.org.wildfly.checkstyle-config>1.0.8.Final</version.org.wildfly.checkstyle-config>
@@ -490,9 +493,35 @@
 
             <!-- Stuff used for testing only -->
             <dependency>
+                <!-- Not sure why the wildfly and wildfly-core upgrades made this necessary -->
+                <groupId>org.wildfly.arquillian</groupId>
+                <artifactId>wildfly-arquillian-container-managed</artifactId>
+                <scope>test</scope>
+                <version>${version.arquillian}</version>
+            </dependency>
+            <dependency>
+                <!-- Not sure why the wildfly and wildfly-core upgrades made this necessary -->
+                <groupId>org.wildfly.arquillian</groupId>
+                <artifactId>wildfly-arquillian-protocol-jmx</artifactId>
+                <scope>test</scope>
+                <version>${version.arquillian}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.jboss.arquillian.junit</groupId>
                 <artifactId>arquillian-junit-container</artifactId>
                 <version>${version.arquillian-junit}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wildfly.glow</groupId>
+                <artifactId>wildfly-glow-core</artifactId>
+                <scope>test</scope>
+                <version>${version.wildfly.glow}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wildfly.glow</groupId>
+                <artifactId>wildfly-glow-maven-resolver</artifactId>
+                <scope>test</scope>
+                <version>${version.wildfly.glow}</version>
             </dependency>
             <dependency>
                 <groupId>org.wildfly.security</groupId>
@@ -553,6 +582,13 @@
                 <groupId>io.rest-assured</groupId>
                 <artifactId>rest-assured</artifactId>
                 <version>${version.rest-assured}</version>
+            </dependency>
+            <!-- Not sure why the wildfly and wildfly-core upgrades made this necessary -->
+            <dependency>
+                <groupId>org.testng</groupId>
+                <artifactId>testng</artifactId>
+                <version>${version.org.testng}</version>
+                <scope>test</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
         <version.org.wildfly>28.0.1.Final</version.org.wildfly>
         <version.org.wildfly.core>20.0.1.Final</version.org.wildfly.core>
         <version.org.wildfly.common>1.6.0.Final</version.org.wildfly.common>
-        <version.org.jboss.galleon>5.1.0.Final</version.org.jboss.galleon>
+        <version.org.jboss.galleon>5.2.0.Final</version.org.jboss.galleon>
 
         <!-- Other WildFly feature pack that we depend on -->
         <version.org.wildfly.reactive-feature-pack>3.0.0.Final</version.org.wildfly.reactive-feature-pack> 

--- a/testsuite/client-vertx/pom.xml
+++ b/testsuite/client-vertx/pom.xml
@@ -150,6 +150,36 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.wildfly.glow</groupId>
+                <artifactId>wildfly-glow-arquillian-plugin</artifactId>
+                <configuration>
+                    <feature-packs>
+                        <feature-pack>
+                            <groupId>org.wildfly</groupId>
+                            <artifactId>wildfly-galleon-pack</artifactId>
+                            <version>${version.org.wildfly}</version>
+                        </feature-pack>
+                        <feature-pack>
+                            <groupId>${project.groupId}</groupId>
+                            <artifactId>wildfly-microprofile-graphql-feature-pack</artifactId>
+                            <version>${project.version}</version>
+                        </feature-pack>
+                    </feature-packs>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>scan-graphql</id>
+                        <goals>
+                            <goal>scan</goal>
+                        </goals>
+                        <phase>test-compile</phase>
+                        <configuration>
+                            <expected-discovery>[cdi, microprofile-config, microprofile-graphql]==>ee-core-profile-server,microprofile-graphql</expected-discovery>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.jboss.galleon</groupId>
                 <artifactId>galleon-maven-plugin</artifactId>
                 <executions>
@@ -157,9 +187,9 @@
                     <execution>
                         <id>server-provisioning</id>
                         <goals>
-                            <goal>provision</goal>
+                            <goal>provision-file</goal>
                         </goals>
-                        <phase>compile</phase>
+                        <phase>process-test-classes</phase>
                         <configuration>
                             <install-dir>${project.build.directory}/wildfly</install-dir>
                             <record-state>false</record-state>
@@ -169,36 +199,7 @@
                                 <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                 <optional-packages>passive+</optional-packages>
                             </plugin-options>
-                            <feature-packs>
-                                <feature-pack>
-                                    <transitive>true</transitive>
-                                    <groupId>org.wildfly</groupId>
-                                    <artifactId>wildfly-galleon-pack</artifactId>
-                                    <version>${version.org.wildfly}</version>
-                                    <inherit-packages>false</inherit-packages>
-                                    <inherit-configs>false</inherit-configs>
-                                </feature-pack>
-                                <feature-pack>
-                                    <groupId>${project.groupId}</groupId>
-                                    <artifactId>wildfly-microprofile-graphql-feature-pack</artifactId>
-                                    <version>${project.version}</version>
-                                    <inherit-packages>false</inherit-packages>
-                                    <inherit-configs>false</inherit-configs>
-                                </feature-pack>
-                            </feature-packs>
-                            <configurations>
-                                <config>
-                                    <model>standalone</model>
-                                    <name>standalone.xml</name>
-                                    <layers>
-                                        <layer>jaxrs-server</layer>
-                                        <layer>jmx-remoting</layer>
-                                        <layer>observability</layer>
-                                        <!-- Layers from this FP -->
-                                        <layer>microprofile-graphql</layer>
-                                    </layers>
-                                </config>
-                            </configurations>
+                            <provisioning-file>target/glow-scan/provisioning.xml</provisioning-file>
                         </configuration>
                     </execution>
                 </executions>

--- a/testsuite/client-vertx/pom.xml
+++ b/testsuite/client-vertx/pom.xml
@@ -140,6 +140,11 @@
             <artifactId>wildfly-arquillian-protocol-jmx</artifactId>
             <scope>test</scope>
         </dependency>
+        <!-- required when upgrading to WildFly 30 -->
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-codec</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/testsuite/integration/pom.xml
+++ b/testsuite/integration/pom.xml
@@ -195,6 +195,11 @@
             <groupId>io.vertx</groupId>
             <artifactId>vertx-uri-template</artifactId>
         </dependency>
+        <!-- required when upgrading to WildFly 30 -->
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-codec</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/testsuite/integration/pom.xml
+++ b/testsuite/integration/pom.xml
@@ -205,6 +205,37 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.wildfly.glow</groupId>
+                <artifactId>wildfly-glow-arquillian-plugin</artifactId>
+                <configuration>
+                    <feature-packs>
+                        <feature-pack>
+                            <groupId>org.wildfly</groupId>
+                            <artifactId>wildfly-galleon-pack</artifactId>
+                            <version>${version.org.wildfly}</version>
+                        </feature-pack>
+                        <feature-pack>
+                            <groupId>${project.groupId}</groupId>
+                            <artifactId>wildfly-microprofile-graphql-feature-pack</artifactId>
+                            <version>${project.version}</version>
+                        </feature-pack>
+                    </feature-packs>
+                    <config-name>standalone-graphql.xml</config-name>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>scan-graphql</id>
+                        <goals>
+                            <goal>scan</goal>
+                        </goals>
+                        <phase>test-compile</phase>
+                        <configuration>
+                            <expected-discovery>[bean-validation, cdi, microprofile-config, microprofile-graphql]==>ee-core-profile-server,microprofile-graphql</expected-discovery>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.jboss.galleon</groupId>
                 <artifactId>galleon-maven-plugin</artifactId>
                 <executions>
@@ -212,9 +243,9 @@
                     <execution>
                         <id>server-provisioning</id>
                         <goals>
-                            <goal>provision</goal>
+                            <goal>provision-file</goal>
                         </goals>
-                        <phase>compile</phase>
+                        <phase>process-test-classes</phase>
                         <configuration>
                             <install-dir>${project.build.directory}/wildfly</install-dir>
                             <record-state>false</record-state>
@@ -224,37 +255,7 @@
                                 <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                 <optional-packages>passive+</optional-packages>
                             </plugin-options>
-                            <feature-packs>
-                                <feature-pack>
-                                    <transitive>true</transitive>
-                                    <groupId>org.wildfly</groupId>
-                                    <artifactId>wildfly-galleon-pack</artifactId>
-                                    <version>${version.org.wildfly}</version>
-                                    <inherit-packages>false</inherit-packages>
-                                    <inherit-configs>false</inherit-configs>
-                                </feature-pack>
-                                <feature-pack>
-                                    <groupId>${project.groupId}</groupId>
-                                    <artifactId>wildfly-microprofile-graphql-feature-pack</artifactId>
-                                    <version>${project.version}</version>
-                                    <inherit-packages>false</inherit-packages>
-                                    <inherit-configs>false</inherit-configs>
-                                </feature-pack>
-                            </feature-packs>
-                            <configurations>
-                                <config>
-                                    <model>standalone</model>
-                                    <name>standalone-graphql.xml</name>
-                                    <layers>
-                                        <!-- jaxrs-server and jmx-remoting are needed by Arquillian -->
-                                        <layer>jaxrs-server</layer>
-                                        <layer>jmx-remoting</layer>
-
-                                        <layer>microprofile-platform</layer>
-                                        <layer>microprofile-graphql</layer>
-                                    </layers>
-                                </config>
-                            </configurations>
+                            <provisioning-file>target/glow-scan/provisioning.xml</provisioning-file>
                         </configuration>
                     </execution>
                 </executions>

--- a/testsuite/layer-metadata-tests/pom.xml
+++ b/testsuite/layer-metadata-tests/pom.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>wildfly-microprofile-graphql-testsuite</artifactId>
+        <groupId>org.wildfly.extras.graphql</groupId>
+        <version>2.2.0.Final-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>layers-metadata-tests</artifactId>
+    <name>WildFly MicroProfile GraphQL - Layers Metadata Tests</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.wildfly.extras.graphql</groupId>
+            <artifactId>wildfly-microprofile-graphql-feature-pack</artifactId>
+            <type>pom</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.microprofile.graphql</groupId>
+            <artifactId>microprofile-graphql-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.shrinkwrap</groupId>
+            <artifactId>shrinkwrap-impl-base</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.glow</groupId>
+            <artifactId>wildfly-glow-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.glow</groupId>
+            <artifactId>wildfly-glow-maven-resolver</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy-provisioning-xml</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.testOutputDirectory}/glow/${project.version}</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>${project.basedir}/src/test/resources/glow/latest</directory>
+                                    <filtering>true</filtering>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+        <testResources>
+            <testResource>
+                <directory>src/test/resources</directory>
+                <excludes>
+                    <exclude>wildfly-glow/latest/*</exclude>
+                </excludes>
+                <filtering>true</filtering>
+            </testResource>
+        </testResources>
+    </build>
+
+</project>

--- a/testsuite/layer-metadata-tests/src/test/java/org/wildfly/extras/graphql/feature/pack/test/layers/metadata/GraphqlLayersMetadataTestCase.java
+++ b/testsuite/layer-metadata-tests/src/test/java/org/wildfly/extras/graphql/feature/pack/test/layers/metadata/GraphqlLayersMetadataTestCase.java
@@ -1,0 +1,76 @@
+package org.wildfly.extras.graphql.feature.pack.test.layers.metadata;
+
+import org.eclipse.microprofile.graphql.GraphQLApi;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.wildfly.glow.Arguments;
+import org.wildfly.glow.GlowMessageWriter;
+import org.wildfly.glow.GlowSession;
+import org.wildfly.glow.ScanResults;
+import org.wildfly.glow.maven.MavenResolver;
+
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.Collections;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@GraphQLApi
+public class GraphqlLayersMetadataTestCase {
+
+    private static String URL_PROPERTY = "wildfly-glow-galleon-feature-packs-url";
+    private static Path ARCHIVES_PATH = Paths.get("target/glow-archives");
+
+    @BeforeClass
+    public static void prepareArchivesDirectory() throws Exception {
+        Path glowXmlPath = Paths.get("target/test-classes/glow");
+        System.out.println(glowXmlPath.toUri());
+        System.setProperty(URL_PROPERTY, glowXmlPath.toUri().toString());
+        if (Files.exists(ARCHIVES_PATH)) {
+            Files.walkFileTree(ARCHIVES_PATH, new SimpleFileVisitor<Path>() {
+                @Override
+                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                    Files.delete(file);
+                    return FileVisitResult.CONTINUE;
+                }
+
+                @Override
+                public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
+                    Files.delete(dir);
+                    return FileVisitResult.CONTINUE;
+                }
+            });
+        }
+        Files.createDirectories(ARCHIVES_PATH);
+    }
+
+
+    private static Path createWebArchive(String archiveName) {
+        WebArchive war = ShrinkWrap.create(WebArchive.class);
+        war.addClass(GraphqlLayersMetadataTestCase.class);
+        ZipExporter exporter = war.as(ZipExporter.class);
+        Path path = ARCHIVES_PATH.resolve(archiveName);
+        exporter.exportTo(path.toFile());
+        return path;
+    }
+
+    @Test
+    public void testGraphqlDetected() throws Exception {
+        Path p = createWebArchive("test.war");
+
+        Arguments arguments = Arguments.scanBuilder().setBinaries(Collections.singletonList(p)).build();
+        ScanResults scanResults = GlowSession.scan(MavenResolver.newMavenResolver(), arguments, GlowMessageWriter.DEFAULT);
+        Set<String> foundLayers = scanResults.getDiscoveredLayers().stream().map(l -> l.getName()).collect(Collectors.toSet());
+        Assert.assertTrue(foundLayers.contains("microprofile-graphql"));
+
+    }
+}

--- a/testsuite/layer-metadata-tests/src/test/resources/glow/latest/provisioning-bare-metal.xml
+++ b/testsuite/layer-metadata-tests/src/test/resources/glow/latest/provisioning-bare-metal.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" ?>
+
+<installation xmlns="urn:jboss:galleon:provisioning:3.0">
+    <feature-pack location="org.wildfly:wildfly-galleon-pack:${version.org.wildfly}"/>
+    <feature-pack location="org.wildfly.extras.graphql:wildfly-microprofile-graphql-feature-pack:${project.version}"/>
+</installation>

--- a/testsuite/layer-metadata-tests/src/test/resources/glow/versions.yaml
+++ b/testsuite/layer-metadata-tests/src/test/resources/glow/versions.yaml
@@ -1,0 +1,2 @@
+latest: ${project.version}
+versions: ${project.version}

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -30,6 +30,7 @@
     <packaging>pom</packaging>
 
     <modules>
+        <module>layer-metadata-tests</module>
         <module>integration</module>
         <module>server-tck</module>
         <module>client-vertx</module>

--- a/testsuite/server-tck/pom.xml
+++ b/testsuite/server-tck/pom.xml
@@ -70,6 +70,40 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.wildfly.glow</groupId>
+                <artifactId>wildfly-glow-arquillian-plugin</artifactId>
+                <configuration>
+                    <feature-packs>
+                        <feature-pack>
+                            <groupId>org.wildfly</groupId>
+                            <artifactId>wildfly-galleon-pack</artifactId>
+                            <version>${version.org.wildfly}</version>
+                        </feature-pack>
+                        <feature-pack>
+                            <groupId>${project.groupId}</groupId>
+                            <artifactId>wildfly-microprofile-graphql-feature-pack</artifactId>
+                            <version>${project.version}</version>
+                        </feature-pack>
+                    </feature-packs>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>scan-graphql</id>
+                        <goals>
+                            <goal>scan</goal>
+                        </goals>
+                        <phase>test-compile</phase>
+                        <configuration>
+                            <dependenciesToScan>
+                                <dependency>org.eclipse.microprofile.graphql:microprofile-graphql-server-tck</dependency>
+                                <dependency>org.eclipse.microprofile.graphql:microprofile-graphql-tck</dependency>
+                            </dependenciesToScan>
+                            <expected-discovery>[cdi, jsonb, jsonp, microprofile-config, microprofile-graphql]==>ee-core-profile-server,microprofile-graphql</expected-discovery>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.jboss.galleon</groupId>
                 <artifactId>galleon-maven-plugin</artifactId>
                 <executions>
@@ -77,9 +111,9 @@
                     <execution>
                         <id>server-provisioning</id>
                         <goals>
-                            <goal>provision</goal>
+                            <goal>provision-file</goal>
                         </goals>
-                        <phase>compile</phase>
+                        <phase>process-test-classes</phase>
                         <configuration>
                             <install-dir>${project.build.directory}/wildfly</install-dir>
                             <record-state>false</record-state>
@@ -89,36 +123,7 @@
                                 <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
                                 <optional-packages>passive+</optional-packages>
                             </plugin-options>
-                            <feature-packs>
-                                <feature-pack>
-                                    <transitive>true</transitive>
-                                    <groupId>org.wildfly</groupId>
-                                    <artifactId>wildfly-galleon-pack</artifactId>
-                                    <version>${version.org.wildfly}</version>
-                                    <inherit-packages>false</inherit-packages>
-                                    <inherit-configs>false</inherit-configs>
-                                </feature-pack>
-                                <feature-pack>
-                                    <groupId>${project.groupId}</groupId>
-                                    <artifactId>wildfly-microprofile-graphql-feature-pack</artifactId>
-                                    <version>${project.version}</version>
-                                    <inherit-packages>false</inherit-packages>
-                                    <inherit-configs>false</inherit-configs>
-                                </feature-pack>
-                            </feature-packs>
-                            <configurations>
-                                <config>
-                                    <model>standalone</model>
-                                    <name>standalone.xml</name>
-                                    <layers>
-                                        <layer>jaxrs-server</layer>
-                                        <layer>jmx-remoting</layer>
-                                        <layer>observability</layer>
-                                        <!-- Layers from this FP -->
-                                        <layer>microprofile-graphql</layer>
-                                    </layers>
-                                </config>
-                            </configurations>
+                            <provisioning-file>target/glow-scan/provisioning.xml</provisioning-file>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
* Integrate this feature-pack with WildFly[ Glow tooling](https://github.com/wildfly/wildfly-glow)

* Galleon layer metadata rule added to the Galleon layer: Any class contained in deployment annotated with org.eclipse.microprofile.graphql.* are making the layer microprofile-graphql to be provisioned.

* In order to have this feature-pack integrated in the WildFly 30.0.0.Final Galleon feature-packs registry: https://github.com/wildfly/wildfly-galleon-feature-packs/tree/release we would need a new release of this feature-pack once this PR is merged.
