### PR TITLE
client.vertx module needs to depend on javax.sql.api

### DIFF
--- a/feature-pack/src/main/resources/modules/system/layers/base/io/smallrye/graphql/client/vertx/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/io/smallrye/graphql/client/vertx/main/module.xml
@@ -32,5 +32,6 @@
         <module name="jakarta.enterprise.api"/>
         <module name="io.vertx.core"/>
         <module name="org.jboss.logging"/>
+        <module name="javax.sql.api"/>
     </dependencies>
 </module>


### PR DESCRIPTION
fixes https://github.com/smallrye/smallrye-graphql/issues/2156