### PR TITLE
Impact of the WildFly catalog

### DIFF
--- a/feature-pack/src/main/resources/layers/standalone/microprofile-graphql/layer-spec.xml
+++ b/feature-pack/src/main/resources/layers/standalone/microprofile-graphql/layer-spec.xml
@@ -17,6 +17,9 @@
 
 <layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="microprofile-graphql">
     <props>
+        <prop name="org.wildfly.category" value="Microprofile"/>
+        <prop name="org.wildfly.description" value="Support for microprofile graphql"/>
+        <prop name="org.wildfly.stability" value="community"/>
         <prop name="org.wildfly.rule.annotations" value="org.eclipse.microprofile.graphql"/>
     </props>
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
 
         <!-- Plugin versions and their dependency versions -->
         <version.org.wildfly.checkstyle-config>1.0.8.Final</version.org.wildfly.checkstyle-config>
-        <version.org.wildfly.galleon-plugins>7.1.2.Final</version.org.wildfly.galleon-plugins>
+        <version.org.wildfly.galleon-plugins>8.0.0.Final</version.org.wildfly.galleon-plugins>
         <version.wildfly.maven.plugin>4.1.1.Final</version.wildfly.maven.plugin>
 
         <!-- Misc. -->


### PR DESCRIPTION
@jmartisk this change is required for the future WildFly catalog (you can see a POC of it there https://jfdenise.github.io/wildfly-catalog/38.0.0.Beta1-SNAPSHOT/index.html) that document all our feature-packs.
You will find in the section WildFly feature-pack a section "WildFly MicroProfile GraphQL - Feature Pack".

Then the graphql layer is put in the category "Microprofile". You can check if that is fine for you.

We plan to have the catalog in place for WildFLy 39, but the sooner we have integrated such changes the better.

The bump to galleon-plugins 8.0.0.Final implies a minimum JDK version of JDK17. I suspect that we will have to change the CI. A new artifact (classifier doc) will be deployed when you release the feature-pack. This artifact contains some documentation that the catalog requires.

Let me know if that is fine with you. I can proceed with the CI fix too.
