### PR TITLE
[Issue_276] Update the feature-pack to allow for provisioning with Wi…

### DIFF
--- a/feature-pack/wildfly-feature-pack-build.xml
+++ b/feature-pack/wildfly-feature-pack-build.xml
@@ -14,10 +14,10 @@
   ~ limitations under the License.
   -->
 
-<build xmlns="urn:wildfly:feature-pack-build:3.1" producer="org.wildfly.extras.graphql:wildfly-microprofile-graphql-feature-pack">
+<build xmlns="urn:wildfly:feature-pack-build:3.5" producer="org.wildfly.extras.graphql:wildfly-microprofile-graphql-feature-pack">
 
     <transitive>
-        <dependency group-id="org.wildfly" artifact-id="wildfly-ee-galleon-pack">
+        <dependency group-id="org.wildfly" artifact-id="wildfly-ee-galleon-pack" allowedFamily="wildfly:jakarta-ee-10+">
             <name>org.wildfly:wildfly-ee-galleon-pack</name>
             <packages inherit="false">
                 <exclude name="product.conf"/>
@@ -26,7 +26,7 @@
         </dependency>
     </transitive>
     <dependencies>
-        <dependency group-id="org.wildfly" artifact-id="wildfly-galleon-pack">
+        <dependency group-id="org.wildfly" artifact-id="wildfly-galleon-pack" allowedFamily="wildfly:microprofile-7.1+">
             <name>org.wildfly:wildfly-galleon-pack</name>
             <packages inherit="false">
                 <include name="docs.examples"/>

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <version.org.wildfly>39.0.1.Final</version.org.wildfly>
         <version.org.wildfly.core>31.0.3.Final</version.org.wildfly.core>
         <version.org.wildfly.common>1.6.0.Final</version.org.wildfly.common>
-        <version.org.jboss.galleon>7.0.5.Final</version.org.jboss.galleon>
+        <version.org.jboss.galleon>7.0.7.Final</version.org.jboss.galleon>
 
         <!-- Libraries provided by this feature pack. These variables directly affect what will be in
              the built feature pack. -->


### PR DESCRIPTION
…ldFly EE-10 variant

Resolves #276 

@jfdenise If anything else is needed, please let me know. I suspect the Galleon 7.0.7 update is not needed, but I went ahead and included it. Dependabot had already moved this repo to the 8.1.3 galleon plugin.

@jmartisk FYI, we're planning to release WildFly 40 tomorrow. That's when this becomes useful.